### PR TITLE
Environmental variable support

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -35,6 +35,19 @@ class Settings extends Model
     // Public Methods
     // =========================================================================
 
+    public function behaviors()
+    {
+        return [
+            'parser' => [
+                'class' => EnvAttributeParserBehavior::class,
+                'attributes' => [
+                    'apiKey',
+                    'clientId',
+                ],
+            ],
+        ];
+    }
+
     /**
      * @inheritdoc
      */
@@ -46,5 +59,25 @@ class Settings extends Model
             [['clientId'], 'string'],
             [['clientId'], 'required'],
         ];
+    }
+
+    /**
+     * Retrieve parsed API Key
+     * 
+     * @return string
+     */ 
+    public function getApiKey(): string
+    {
+        return Craft::parseEnv($this->apiKey);
+    }
+
+    /**
+     * Retrieve parse Client Id
+     * 
+     * @return string
+     */
+    public function getClientId(): string
+    {
+        return Craft::parseEnv($this->clientId);
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -36,6 +36,9 @@ class Settings extends Model
     // Public Methods
     // =========================================================================
 
+    /**
+     * @inheritdoc
+     */
     public function behaviors()
     {
         return [

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -13,6 +13,7 @@ use clearbold\cmservice\CmService;
 
 use Craft;
 use craft\base\Model;
+use craft\behaviors\EnvAttributeParserBehavior;
 
 /**
  * @author    Mark Reeves, Clearbold, LLC <hello@clearbold.com>

--- a/src/services/CampaignMonitorService.php
+++ b/src/services/CampaignMonitorService.php
@@ -26,25 +26,42 @@ use craft\base\Component;
 class CampaignMonitorService extends Component
 {
     /**
-     * @var settings
-     * @todo declare it once
+     * @var string
      */
+    private $apiKey;
+
+    /**
+     * @var string
+     */
+    private $clientId;
 
     // Public Methods
     // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+
+        $settings = CmService::$plugin->getSettings();
+        $this->apiKey = $settings->getApiKey();
+        $this->clientId = $settings->getClientId();
+    }
 
     /*
      * @return mixed
      */
     public function getLists()
     {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Clients(
-                $settings->clientId,
+                $this->clientId,
                 $auth);
 
             $result = $client->get_lists();
@@ -76,11 +93,11 @@ class CampaignMonitorService extends Component
 
     public function getListStats($listId = '')
     {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Lists(
                 $listId,
                 $auth);
@@ -110,11 +127,11 @@ class CampaignMonitorService extends Component
 
     public function getList($listId = '')
     {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Lists(
                 $listId,
                 $auth);
@@ -143,11 +160,11 @@ class CampaignMonitorService extends Component
     }
 
     public function getActiveSubscribers($listId = '', $params = []) {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Lists(
                 $listId,
                 $auth);
@@ -180,11 +197,11 @@ class CampaignMonitorService extends Component
      */
     public function importSubscribers($listId = '', $subscribers = array())
     {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Subscribers(
                 $listId,
                 $auth);
@@ -216,11 +233,11 @@ class CampaignMonitorService extends Component
      * @return mixed
      */
     public function updateSubscriber($listId = '', $oldEmail = '', $email = '', $subscriber = array()) {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Subscribers(
                 $listId,
                 $auth);
@@ -253,11 +270,11 @@ class CampaignMonitorService extends Component
      */
     public function addSubscriber($listId = '', $subscriber = array())
     {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Subscribers(
                 $listId,
                 $auth);
@@ -287,11 +304,11 @@ class CampaignMonitorService extends Component
 
     public function unsubSubscriber($listId = '', $email = '')
     {
-        $settings = CmService::$plugin->getSettings();
-
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Subscribers(
                 $listId,
                 $auth);
@@ -325,8 +342,6 @@ class CampaignMonitorService extends Component
     // public function createCampaign($campaign = array())
     public function createCampaign()
     {
-        $settings = CmService::$plugin->getSettings();
-
         $campaign = array(
             'Subject' => 'Campaign Subject',
             'Name' => 'Campaign Name',
@@ -340,8 +355,10 @@ class CampaignMonitorService extends Component
         );
 
         try {
-            $auth = array(
-                'api_key' => (string)$settings->apiKey);
+            $auth = [
+                'api_key' => $this->apiKey,
+            ];
+
             $client = new \CS_REST_Campaigns(
                 NULL,
                 $auth);

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -1,6 +1,6 @@
 {% import '_includes/forms' as forms %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     first:        true,
     required:     true,
     label:        'API Key',
@@ -8,15 +8,17 @@
     id:           'apiKey',
     name:         'apiKey',
     placeholder:  '',
-    value:        settings.apiKey
+    value:        settings.apiKey,
+    suggestEnvVars: true
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     required:     true,
     label:        'Client ID',
     instructions: '',
     id:           'clientId',
     name:         'clientId',
     placeholder:  '',
-    value:        settings.clientId
+    value:        settings.clientId,
+    suggestEnvVars: true
 }) }}


### PR DESCRIPTION
Added the option to use environmental variables within settings for the plugin.  The reason for this is to avoid API keys being stored in `project.yaml`.

Also moved the retrieval / parsing of the apiKey / clientId within `CampaignMonitorService` to the `init()` method. 